### PR TITLE
pt-br must use br.map.gz

### DIFF
--- a/keyboard/src/data/keyboard_raw.ycp
+++ b/keyboard/src/data/keyboard_raw.ycp
@@ -216,7 +216,7 @@ return ($[
 	// keyboard layout
 	_("Portuguese (Brazil)"),
 	$[
-	    "pc104"	: $[ "ncurses": "br-nativo.map.gz"],
+	    "pc104"	: $[ "ncurses": "br.map.gz"],
 	    "macintosh" : $[ "ncurses": "us-mac.map.gz"],
 	    "type4"	: $[ "ncurses": "us.map.gz"],
 	    "type5"	: $[ "ncurses": "us.map.gz" ],


### PR DESCRIPTION
br-nativo.map.gz is a Dvorak layout (almost no one uses)
A keyboard "portugese-br" should use the layout br.map.gz